### PR TITLE
Fix missing context test

### DIFF
--- a/src/test/java/com/acme/superapp/SuperappApplicationTests.java
+++ b/src/test/java/com/acme/superapp/SuperappApplicationTests.java
@@ -7,5 +7,8 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest
 @ActiveProfiles("test")
 class SuperappApplicationTests {
-	// vacío: solo comprueba que el contexto arranca
+        // vacío: solo comprueba que el contexto arranca
+        @Test
+        void contextLoads() {
+        }
 }


### PR DESCRIPTION
## Summary
- add `contextLoads` test

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6841a0dae7f88333b7c1b280c8b898f4